### PR TITLE
Use serial numbers in reset method

### DIFF
--- a/rp2040_u2if.py
+++ b/rp2040_u2if.py
@@ -109,7 +109,7 @@ class RP2040_u2if:
         start = time.monotonic()
         while time.monotonic() - start < 5:
             try:
-                self._hid.open(self._vid, self._pid)
+                self._hid.open(self._vid, self._pid, self._serial)
             except OSError:
                 time.sleep(0.1)
                 continue


### PR DESCRIPTION
Looking over the code, I discovered that in the `reset` method, the serial number is not explicitly specified when opening the device again. This is a simple fix to specify the serial number.